### PR TITLE
add networking statistics to System report

### DIFF
--- a/otestpoint/system/network.proto
+++ b/otestpoint/system/network.proto
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2018 - Adjacent Link LLC, Bridgewater, New Jersey
+ * Copyright (c) 2020 - IBM
+ * All rights reserved.
+ *
+ * Parts of this development was sponsored by the U.S. Army Research
+ * Laboratory and the U.K. Ministry of Defence under Agreement Number
+ * W911NF-16-3-0001. The views and conclusions contained in this
+ * document are those of the authors and should not be interpreted as
+ * representing the official policies, either expressed or implied,
+ * of the U.S. Army Research Laboratory, the U.S. Government, the
+ * U.K. Ministry of Defence or the U.K. Government. The U.S. and U.K.
+ * Governments are authorized to reproduce and distribute copies
+ * for Government purposes notwithstanding any copyright notation
+ * hereon.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  * Neither the name of Adjacent Link LLC nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * See toplevel COPYING for more information.
+ */
+
+syntax="proto2";
+
+package OpenTestPoint;
+
+option optimize_for = SPEED;
+
+import "measurementtable.proto";
+
+message Measurement_system_network
+{
+  message Description
+  {
+    required string name = 1 [default = "Measurement_system_network"];
+    required string module = 2 [default = "otestpoint.system.network"];
+    required uint32 version = 3 [default = 1];
+  }
+  // do not set description
+  optional Description description = 1;
+
+  optional MeasurementTable network = 2;
+}

--- a/otestpoint/system/network.py
+++ b/otestpoint/system/network.py
@@ -1,0 +1,214 @@
+#
+# Copyright (c) 2018,2019 - Adjacent Link LLC, Bridgewater, New Jersey
+# Copyright (c) 2020 - IBM
+# All rights reserved.
+#
+# Parts of this development was sponsored by the U.S. Army Research
+# Laboratory and the U.K. Ministry of Defence under Agreement Number
+# W911NF-16-3-0001. The views and conclusions contained in this
+# document are those of the authors and should not be interpreted as
+# representing the official policies, either expressed or implied,
+# of the U.S. Army Research Laboratory, the U.S. Government, the
+# U.K. Ministry of Defence or the U.K. Government. The U.S. and U.K.
+# Governments are authorized to reproduce and distribute copies
+# for Government purposes notwithstanding any copyright notation
+# hereon.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+#  * Neither the name of Adjacent Link LLC nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# See toplevel COPYING for more information.
+#
+
+'''
+System Network Probe
+'''
+
+import psutil
+import time
+
+from otestpoint.interface import Probe
+from otestpoint.interface.measurementtable_pb2 import MeasurementTable
+import otestpoint.toolkit.logger as Logger
+from .network_pb2 import Measurement_system_network
+
+
+class Network(Probe):
+    def initialize(self,configurationFile=None):
+        '''
+        Initialize the probe.
+
+        Returns:
+        The probe name list.
+        '''
+        self._logger.log(Logger.DEBUG_LEVEL,
+                         '/system/network initialize'
+                         ' configuration: %s' % configurationFile)
+
+        self._measurement = Measurement_system_network()
+
+        '''
+        bytes_sent: number of bytes sent
+        bytes_recv: number of bytes received
+        packets_sent: number of packets sent
+        packets_recv: number of packets received
+        errin: total number of errors while receiving
+        errout: total number of errors while sending
+        dropin: total number of incoming packets which were dropped
+        dropout: total number of outgoing packets which were dropped (always 0 on macOS and BSD)
+        '''
+        self._measurement_network_labels = ('nic',
+                                         'bytes_sent',
+                                         'bytes_recv',
+                                         'packets_sent',
+                                         'packets_recv',
+                                         'errin',
+                                         'errout',
+                                         'dropin',
+                                         'dropout')
+
+        self._measurement.network.labels.extend(self._measurement_network_labels)
+
+        return ('System.Network',)
+
+
+    def start(self):
+        self._logger.log(Logger.DEBUG_LEVEL,'/system/network start')
+
+
+    def stop(self):
+        self._logger.log(Logger.DEBUG_LEVEL,'/system/network stop')
+
+
+    def destroy(self):
+        self._logger.log(Logger.DEBUG_LEVEL,'/system/network destroy')
+
+
+    def probe(self):
+        self._logger.log(Logger.DEBUG_LEVEL,'/system/network probe')
+
+        self.parse_net_io_counters()
+
+        return (('System.Network',
+                 self._measurement.SerializeToString(),
+                 self._measurement.description.name,
+                 self._measurement.description.module,
+                 self._measurement.description.version),)
+
+
+    def parse_net_io_counters(self):
+        del self._measurement.network.rows[:]
+
+        for nic,nic_counters in psutil.net_io_counters(pernic=True).items():
+                row = self._measurement.network.rows.add()
+
+                # NIC
+                value = row.values.add()
+                value.type = MeasurementTable.Measurement.TYPE_STRING
+                value.sValue = nic
+
+                # bytes_sent
+                value = row.values.add()
+                value.type = MeasurementTable.Measurement.TYPE_UINTEGER
+                value.uValue = nic_counters.bytes_sent
+
+                # bytes_recv
+                value = row.values.add()
+                value.type = MeasurementTable.Measurement.TYPE_UINTEGER
+                value.uValue = nic_counters.bytes_recv
+
+                # packets_sent
+                value = row.values.add()
+                value.type = MeasurementTable.Measurement.TYPE_UINTEGER
+                value.uValue = nic_counters.packets_sent
+
+                # packets_recv
+                value = row.values.add()
+                value.type = MeasurementTable.Measurement.TYPE_UINTEGER
+                value.uValue = nic_counters.packets_recv
+
+                # errin
+                value = row.values.add()
+                value.type = MeasurementTable.Measurement.TYPE_UINTEGER
+                value.uValue = nic_counters.errin
+
+                # errout
+                value = row.values.add()
+                value.type = MeasurementTable.Measurement.TYPE_UINTEGER
+                value.uValue = nic_counters.errout
+
+                # dropin
+                value = row.values.add()
+                value.type = MeasurementTable.Measurement.TYPE_UINTEGER
+                value.uValue = nic_counters.dropin
+
+                # dropout
+                value = row.values.add()
+                value.type = MeasurementTable.Measurement.TYPE_UINTEGER
+                value.uValue = nic_counters.dropout
+
+
+
+def default_method_format(self, measurement):
+    def fromMeasurement(measurement):
+        if measurement.type == MeasurementTable.Measurement.TYPE_UINTEGER:
+            return measurement.uValue,str(measurement.uValue)
+        elif measurement.type == MeasurementTable.Measurement.TYPE_DOUBLE:
+            return measurement.dValue,'%0.2f' % measurement.dValue
+        else:
+            return measurement.sValue,measurement.sValue
+
+
+    def format_table(table):
+        buf = ''
+
+        widths = [];
+
+        for label in table.labels:
+            widths.append(len(label))
+
+        for row in table.rows:
+            for i,value in enumerate(row.values):
+                widths[i] = max(widths[i],len(fromMeasurement(value)[1]))
+
+        for i,label in enumerate(table.labels):
+            buf += '|' + label.ljust(widths[i])
+        buf += "|\n"
+
+        for row in table.rows:
+            for i,value in enumerate(row.values):
+                val = fromMeasurement(value)[1]
+                buf += '|' + val.rjust(widths[i])
+            buf += "|\n"
+
+        return buf
+
+    buf = '[] network\n'
+    buf += format_table(measurement.network)
+    buf += '--\n'
+
+    return buf


### PR DESCRIPTION
It's handy to have some basic network statistics such as inbound and outbound data so I've added an additional probe that does just that.

This is the same changes as PR #4, but on the develop branch